### PR TITLE
Load palette to main view & refactoring

### DIFF
--- a/components.js
+++ b/components.js
@@ -1,0 +1,28 @@
+import { REMOVE_IMG_PATH } from "./data.js";
+
+export function createColorContainer(index, palette) {
+  const colorContainer = document.createElement("div");
+  colorContainer.classList.add("mini-colors");
+  colorContainer.dataset.id = index;
+
+  palette.forEach((color) => {
+    colorContainer.appendChild(createMiniColorBox(color.hexCode));
+  });
+
+  return colorContainer;
+}
+
+function createMiniColorBox(hexCode) {
+  const miniColorBox = document.createElement("div");
+  miniColorBox.classList.add("mini-color-box");
+  miniColorBox.style.backgroundColor = hexCode;
+  return miniColorBox;
+}
+
+export function createRemovePaletteButton(index) {
+  const removePaletteImage = document.createElement("img");
+  removePaletteImage.src = REMOVE_IMG_PATH;
+  removePaletteImage.classList.add("remove-button");
+  removePaletteImage.dataset.id = index;
+  return removePaletteImage;
+}

--- a/data.js
+++ b/data.js
@@ -6,6 +6,14 @@ export class Color {
     this.isLocked = isLocked;
   }
 
+  lock() {
+    this.isLocked = true;
+  }
+
+  unlock() {
+    this.isLocked = false;
+  }
+
   toggleLock() {
     this.isLocked = !this.isLocked;
   }

--- a/data.js
+++ b/data.js
@@ -26,6 +26,7 @@ export class Color {
   randomHexGenerator() {
     const possibleInt = "0123456789abcdef";
     let hexCode = "#";
+
     for (let index = 0; index < 6; index++) {
       let randInt = Math.floor(Math.random() * possibleInt.length);
       hexCode += possibleInt[randInt];
@@ -42,3 +43,7 @@ export let currentPalette = [
   new Color(),
 ];
 export let paletteArray = [];
+
+export const LOCKED_IMG_PATH = "./assets/locked.png";
+export const UNLOCKED_IMG_PATH = "./assets/unlocked.png";
+export const REMOVE_IMG_PATH = "./assets/delete.png";

--- a/main.js
+++ b/main.js
@@ -66,8 +66,6 @@ function updateColorBoxes() {
 function setBoxHex(index, colorObject) {
   if (index >= allColorContainers.length) return;
   if (currentPalette[index].isLocked) return;
-
-  var colorHex = allColorContainers[index].querySelector(".color-hex");
   currentPalette[index] = colorObject;
   updateColorBoxes();
 }

--- a/main.js
+++ b/main.js
@@ -16,10 +16,12 @@ savedView.addEventListener("click", function (event) {
 
 savedView.addEventListener("click", function (event) {
   var element = event.target;
-  if (element.classList.contains("mini-colors")||element.classList.contains("mini-color-box")) {
+  if (
+    element.classList.contains("mini-colors") ||
+    element.classList.contains("mini-color-box")
+  ) {
     let colorObject = paletteArray[element.parentNode.dataset.miniColorId];
-    console.log(colorObject)
-    fromSavedPalette(colorObject)
+    fromSavedPalette(colorObject);
   }
 });
 
@@ -66,6 +68,7 @@ function updateColorBoxes() {
 function setBoxHex(index, colorObject) {
   if (index >= allColorContainers.length) return;
   if (currentPalette[index].isLocked) return;
+
   currentPalette[index] = colorObject;
   updateColorBoxes();
 }
@@ -76,16 +79,19 @@ function createColorBoxes() {
   }
 }
 
-function fromSavedPalette(colorObject){
+function fromSavedPalette(colorObject) {
   for (let i = 0; i < colorObject.length; i++) {
+    currentPalette[i].unlock();
     setBoxHex(i, colorObject[i]);
-    
   }
-  updateColorBoxes()
+  updateColorBoxes();
 }
 
 function savePalette() {
-  paletteArray.push(structuredClone(currentPalette));
+  let newCurrentPalette = currentPalette.map(
+    (color) => new Color(color.hexCode, color.isLocked)
+  );
+  paletteArray.push(newCurrentPalette);
 }
 
 function updateSavedPalettes() {

--- a/main.js
+++ b/main.js
@@ -14,11 +14,21 @@ savedView.addEventListener("click", function (event) {
   }
 });
 
+savedView.addEventListener("click", function (event) {
+  var element = event.target;
+  if (element.classList.contains("mini-colors")||element.classList.contains("mini-color-box")) {
+    let colorObject = paletteArray[element.parentNode.dataset.miniColorId];
+    console.log(colorObject)
+    fromSavedPalette(colorObject)
+  }
+});
+
 saveButton.addEventListener("click", function () {
   savePalette();
   updateSavedPalettes();
   createColorBoxes();
 });
+
 allLockImages.forEach((image, index) => {
   image.addEventListener("click", () => {
     currentPalette[index].toggleLock();
@@ -68,6 +78,14 @@ function createColorBoxes() {
   }
 }
 
+function fromSavedPalette(colorObject){
+  for (let i = 0; i < colorObject.length; i++) {
+    setBoxHex(i, colorObject[i]);
+    
+  }
+  updateColorBoxes()
+}
+
 function savePalette() {
   paletteArray.push(structuredClone(currentPalette));
 }
@@ -77,10 +95,12 @@ function updateSavedPalettes() {
   updatedPalettes.innerHTML = "";
   for (var i = 0; i < paletteArray.length; i++) {
     const newPalette = document.createElement("li");
+    newPalette.dataset.miniColorId = i;
     newPalette.classList.add("mini-color-container");
 
     const divContainer = document.createElement("div");
     divContainer.classList.add("mini-colors");
+    divContainer.dataset.miniColorId = i;
     for (let j = 0; j < paletteArray[i].length; ++j) {
       var currentColor = paletteArray[i][j];
       const miniColorBox = document.createElement("div");

--- a/main.js
+++ b/main.js
@@ -1,126 +1,111 @@
-import { Color, currentPalette, paletteArray } from "./data.js";
+import {
+  createColorContainer,
+  createRemovePaletteButton,
+} from "./components.js";
+import {
+  Color,
+  LOCKED_IMG_PATH,
+  UNLOCKED_IMG_PATH,
+  currentPalette,
+  paletteArray,
+} from "./data.js";
 
-var allLockImages = document.querySelectorAll("img.lock");
-var allColorContainers = document.querySelectorAll(".color-container");
-var randomButton = document.querySelector(".random-button");
-var saveButton = document.querySelector(".save-button");
-var savedView = document.querySelector(".saved-view");
+const allLockImages = document.querySelectorAll("img.lock");
+const allColorContainers = document.querySelectorAll(".color-container");
+const randomButton = document.querySelector(".random-button");
+const saveButton = document.querySelector(".save-button");
+const savedView = document.querySelector(".saved-view");
 
 savedView.addEventListener("click", function (event) {
-  var element = event.target;
+  const element = event.target;
+
   if (element.classList.contains("remove-button")) {
     paletteArray.splice(element.dataset.id, 1);
     updateSavedPalettes();
-  }
-});
-
-savedView.addEventListener("click", function (event) {
-  var element = event.target;
-  if (
+  } else if (
     element.classList.contains("mini-colors") ||
     element.classList.contains("mini-color-box")
   ) {
-    let colorObject = paletteArray[element.parentNode.dataset.miniColorId];
-    fromSavedPalette(colorObject);
+    let id = element.parentNode.dataset.id;
+    loadPalette(paletteArray[id]);
   }
 });
 
 saveButton.addEventListener("click", function () {
   savePalette();
-  updateSavedPalettes();
-  createColorBoxes();
+  generateNewPalette();
 });
 
 allLockImages.forEach((image, index) => {
   image.addEventListener("click", () => {
     currentPalette[index].toggleLock();
-    updateColorBoxes();
+    updateCurrentPalette();
   });
 });
-randomButton.addEventListener("click", function (event) {
-  createColorBoxes();
-});
+
+randomButton.addEventListener("click", generateNewPalette);
 
 init();
 
 function init() {
-  updateColorBoxes();
+  updateCurrentPalette();
 }
 
-function updateColorBoxes() {
+function setPaletteIndex(index, colorObject) {
+  if (index >= allColorContainers.length) return;
+  if (currentPalette[index].isLocked) return;
+
+  currentPalette[index] = colorObject;
+  updateCurrentPalette();
+}
+
+function generateNewPalette() {
+  for (var i = 0; i < currentPalette.length; i++) {
+    setPaletteIndex(i, new Color());
+  }
+}
+
+function loadPalette(paletteArray) {
+  for (let i = 0; i < paletteArray.length; i++) {
+    currentPalette[i].unlock();
+    setPaletteIndex(i, paletteArray[i]);
+  }
+}
+
+function savePalette() {
+  const savedPalette = currentPalette.map(
+    (color) => new Color(color.hexCode, color.isLocked)
+  );
+  paletteArray.push(savedPalette);
+  updateSavedPalettes();
+}
+
+function updateCurrentPalette() {
   allColorContainers.forEach((container, index) => {
     const colorBox = container.querySelector(".color-box");
     const colorHex = container.querySelector(".color-hex");
     const colorLock = container.querySelector("img");
+
     const hexCode = currentPalette[index].hexCode;
+    const isLocked = currentPalette[index].isLocked;
 
-    if (currentPalette[index].isLocked) {
-      colorLock.src = "./assets/locked.png";
-    } else {
-      colorLock.src = "./assets/unlocked.png";
-    }
-
+    colorLock.src = isLocked ? LOCKED_IMG_PATH : UNLOCKED_IMG_PATH;
     colorBox.style.backgroundColor = hexCode;
     colorHex.innerText = hexCode;
   });
 }
 
-function setBoxHex(index, colorObject) {
-  if (index >= allColorContainers.length) return;
-  if (currentPalette[index].isLocked) return;
-
-  currentPalette[index] = colorObject;
-  updateColorBoxes();
-}
-
-function createColorBoxes() {
-  for (var i = 0; i < allColorContainers.length; i++) {
-    setBoxHex(i, new Color());
-  }
-}
-
-function fromSavedPalette(colorObject) {
-  for (let i = 0; i < colorObject.length; i++) {
-    currentPalette[i].unlock();
-    setBoxHex(i, colorObject[i]);
-  }
-  updateColorBoxes();
-}
-
-function savePalette() {
-  let newCurrentPalette = currentPalette.map(
-    (color) => new Color(color.hexCode, color.isLocked)
-  );
-  paletteArray.push(newCurrentPalette);
-}
-
 function updateSavedPalettes() {
-  var updatedPalettes = document.querySelector(".saved-palettes");
-  updatedPalettes.innerHTML = "";
-  for (var i = 0; i < paletteArray.length; i++) {
-    const newPalette = document.createElement("li");
-    newPalette.dataset.miniColorId = i;
-    newPalette.classList.add("mini-color-container");
+  const savedPalettesNode = document.querySelector(".saved-palettes");
+  savedPalettesNode.innerHTML = "";
 
-    const divContainer = document.createElement("div");
-    divContainer.classList.add("mini-colors");
-    divContainer.dataset.miniColorId = i;
-    for (let j = 0; j < paletteArray[i].length; ++j) {
-      var currentColor = paletteArray[i][j];
-      const miniColorBox = document.createElement("div");
+  paletteArray.forEach((palette, index) => {
+    const paletteListItem = document.createElement("li");
+    paletteListItem.dataset.id = index;
+    paletteListItem.classList.add("mini-color-container");
 
-      miniColorBox.classList.add("mini-color-box");
-      miniColorBox.style.backgroundColor = currentColor.hexCode;
-      divContainer.appendChild(miniColorBox);
-    }
-    newPalette.appendChild(divContainer);
-
-    const removeButton = document.createElement("img");
-    removeButton.src = "./assets/delete.png";
-    removeButton.classList.add("remove-button");
-    removeButton.dataset.id = i;
-    newPalette.appendChild(removeButton);
-
-    updatedPalettes.appendChild(newPalette);
-  }
+    paletteListItem.appendChild(createColorContainer(index, palette));
+    paletteListItem.appendChild(createRemovePaletteButton(index));
+    savedPalettesNode.appendChild(paletteListItem);
+  });
 }

--- a/styles.css
+++ b/styles.css
@@ -1,23 +1,20 @@
 :root {
   --color-background: #e5f1f1;
 
-  --title-size: 5rem;
-  --other-font-size: 1.5rem;
-  --main-margin: 3ch;
+  --main-title-size: 5rem;
+  --saved-title-size: 2rem;
+  --text-font-size: 1.5rem;
 
   --box-size: 150px;
   --box-border: 5px solid black;
-
   --mini-box-size: 40px;
   --mini-box-border: 4px solid black;
+
+  --lock-img-size: 20%;
 
   --button-height: 50px;
   --button-width: 250px;
   --button-font-size: 1.5rem;
-
-  --lock-img-size: 20%;
-
-  --saved-title-size: 2rem;
 }
 
 html,
@@ -61,7 +58,7 @@ body {
 
     li {
       list-style-type: none;
-      font-size: var(--other-font-size);
+      font-size: var(--text-font-size);
       margin-bottom: 30px;
     }
 
@@ -107,7 +104,7 @@ body {
     text-align: center;
     justify-self: center;
 
-    font-size: var(--title-size);
+    font-size: var(--main-title-size);
     text-transform: uppercase;
   }
 
@@ -137,7 +134,7 @@ body {
     }
 
     .color-hex {
-      font-size: var(--other-font-size);
+      font-size: var(--text-font-size);
       text-transform: uppercase;
     }
 


### PR DESCRIPTION
A new feature was added for loading palettes pack into main view. Extra locking abilities were added to Color objects to support this.

A bug was found preventing direct input of the objects from the paletteArray into the currentPalette. Due to the use of structureClone in savePalette, a Color object was not being inputed into the array, but a shallow copy. Using the map function, we now have a better copied Color object in the array, allowing us to use Color methods.

The biggest change was refactoring done to make the code more clean and readable. updateSavePalettes was broken into smaller functions for more readability. These smaller functions were then moved into a new file to keep main.js clean. Certain variables and functions were renamed to maintain consistency with previous naming conventions.